### PR TITLE
Update the logic to be more generic

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -103,8 +103,24 @@ type Config struct {
 	// MitmCa is used to provide a custom CA for MITM
 	MitmTLSConfig func(host string, ctx *goproxy.ProxyCtx) (*tls.Config, error)
 
-	// IsVPCEndpointRemappingEnabled is a function that returns a boolean indicating whether to remap the original host to the privatelink VPC endpoint.
-	IsVPCEndpointRemappingEnabled func() bool
+	// HostRemapConfig configures any host remapping that should be done by the proxy.
+	HostRemapConfig *hostRemapConfig
+}
+
+// hostRemapConfig configures host remapping settings.
+type hostRemapConfig struct {
+	// IsEnabled returns true if host remapping is enabled.
+	IsEnabled func() bool
+	// Mappings is a map of the original hostnames to their remapped values.
+	Mappings map[string]string
+}
+
+// NewHostRemapConfig creates a new hostRemapConfig with default values.
+func NewHostRemapConfig() hostRemapConfig {
+	return hostRemapConfig{
+		IsEnabled: func() bool { return false },
+		Mappings:  make(map[string]string),
+	}
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -651,24 +651,17 @@ func extractContextLogFields(pctx *goproxy.ProxyCtx, sctx *SmokescreenContext) l
 	return fields
 }
 
-var vpceMap = initVPCEMap()
-
-// TODO(xwen-figma): pass in the environment variables from the k8s configs and add other endpoints.
-func initVPCEMap() map[string]string {
-	return map[string]string{
-		"agent-http-intake.logs.datadoghq.com": os.Getenv("DD_VPCE_DNS_LOGS_AGENT"),
-		// Add other endpoints as needed
+func remapHost(config *Config, destination *hostport.HostPort, sctx *SmokescreenContext) {
+	if config.HostRemapConfig == nil {
+		return
 	}
-}
-
-func remapHost(destination hostport.HostPort, sctx *SmokescreenContext) {
-	for originalHost, vpceHost := range vpceMap {
+	for originalHost, newHost := range config.HostRemapConfig.Mappings {
 		if strings.Contains(destination.Host, originalHost) {
-			if vpceMap[originalHost] != "" {
-				sctx.logger.Infof("Remapping %s to %s", destination.Host, vpceMap[originalHost])
-				destination.Host = vpceHost
+			if newHost != "" {
+				sctx.logger.Infof("Remapping the original host: %s to new host: %s", destination.Host, newHost)
+				destination.Host = newHost
 			} else {
-				sctx.logger.Warnf("DD privatelink environment variable for: %s is not set, cannot remap", originalHost)
+				sctx.logger.Debugf("Remapping value for: %s is not set, no remap", originalHost)
 			}
 		}
 	}
@@ -684,10 +677,9 @@ func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (*goproxy.ConnectActi
 		return nil, "", pctx.Error
 	}
 
-	// Remap host to VPC endpoint of PrivateLink if necessary
-	if config.IsVPCEndpointRemappingEnabled != nil && config.IsVPCEndpointRemappingEnabled() {
-		sctx.logger.Infof("VPC endpoint remapping is enabled")
-		remapHost(destination, sctx)
+	if config.HostRemapConfig != nil && config.HostRemapConfig.IsEnabled != nil && config.HostRemapConfig.IsEnabled() {
+		sctx.logger.Infof("Host remapping is enabled")
+		remapHost(config, &destination, sctx)
 	}
 
 	// checkIfRequestShouldBeProxied can return an error if either the resolved address is disallowed,


### PR DESCRIPTION
If we hope to upstream the change eventually, we can make it more generic, and not limited to VPCE and privatelink use case